### PR TITLE
MC-136: Only used configurable attributes are now chosen to build configurable product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  - Delta Export is directly integrated in MagentoConnector (DeltaExportBundle is now deprecated)
  - Connector Mapping is directly integrated in MagentoConnector (ConnectorMappingBundle is now deprecated)
  - Attribute, Category, Family and Option normalizers are now in the DI
+ - Only used configurable attributes are now chosen to build configurable product
 
 ## BC Breaks
  - All DeltaExportBundle dependencies should be replaced by MagentoConnectorBundle ones


### PR DESCRIPTION
Bug fix: [yes]
Feature addition: [no]
Backwards compatibility break: [no]
Phpspec specification passes: [no]
Checkstyle issues: [no]
ChangeLog updated: [yes]
Fixes the following issue: Incorrect configurable attributes chosen in case not all used to build configurable product