### PR TITLE
MC-136: Only used configurable attributes are now added to build configurable product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  - Add an option to avoid generating category URL_KEY and let Magento handle it.
  - Add an option to set the is_anchor property for all categories.
  - Add an option to force attribute set removal.
+ - Only used configurable attributes are now added to build configurable product.
 
 ## Bug fixes
  - option "Do nothing" didn't prevent removal of empty families, it now does.

--- a/Normalizer/ConfigurableNormalizer.php
+++ b/Normalizer/ConfigurableNormalizer.php
@@ -128,6 +128,7 @@ class ConfigurableNormalizer extends AbstractNormalizer
 
     /**
      * Get default configurable
+     *
      * @param Group             $group
      * @param string            $sku
      * @param int               $attributeSetId
@@ -142,6 +143,8 @@ class ConfigurableNormalizer extends AbstractNormalizer
      * @param bool              $create
      *
      * @return array
+     *
+     * @throws InvalidPriceMappingException
      */
     protected function getDefaultConfigurable(
         Group $group,
@@ -194,8 +197,18 @@ class ConfigurableNormalizer extends AbstractNormalizer
         $defaultProductValues[ProductNormalizer::VISIBILITY] = $this->visibility;
         $defaultProductValues[ProductNormalizer::URL_KEY] = $defaultProductValues[ProductNormalizer::URL_KEY].'-conf-'.$group->getId();
 
+        $configurableAttributes['configurable_attributes'] = [];
+        $attributes = $group->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            $magentoAttributeCode = $attributeMapping->getTarget($attribute->getCode());
+            $magentoAttributeId = $magentoAttributes[$magentoAttributeCode]['attribute_id'];
+            $configurableAttributes['configurable_attributes'][] = $magentoAttributeId;
+        }
+
         $defaultConfigurableValues = array_merge(
             $defaultProductValues,
+            $configurableAttributes,
             $priceMapping,
             [self::ASSOCIATED_SKUS => $associatedSkus]
         );


### PR DESCRIPTION
Bug fix: [yes]
Feature addition: [no]
Backwards compatibility break: [no]
Phpspec specification passes: [no]
Checkstyle issues: [no]
ChangeLog updated: [yes]
Fixes the following issue: MC-136: Incorrect configurable attributes chosen in case not all used to build configurable product