### PR TITLE
MC-90: Soap fault codes thrown by Magento are string type, not integer.

### DIFF
--- a/Cleaner/CategoryCleaner.php
+++ b/Cleaner/CategoryCleaner.php
@@ -20,7 +20,8 @@ use Akeneo\Bundle\BatchBundle\Item\InvalidItemException;
  */
 class CategoryCleaner extends Cleaner
 {
-    const SOAP_FAULT_NO_CATEGORY = 102;
+    /** @staticvar string */
+    const SOAP_FAULT_NO_CATEGORY = '102';
 
     /** @var CategoryMappingManager */
     protected $categoryMappingManager;

--- a/Writer/AttributeWriter.php
+++ b/Writer/AttributeWriter.php
@@ -22,9 +22,14 @@ use Pim\Bundle\MagentoConnectorBundle\Webservice\MagentoSoapClientParametersRegi
  */
 class AttributeWriter extends AbstractWriter
 {
+    /** @staticvar int */
     const ATTRIBUTE_UPDATE_SIZE               = 2;
-    const SOAP_FAULT_ATTRIBUTE_ALREADY_IN_SET = 109;
-    const SOAP_FAULT_GROUP_ALREADY_IN_SET     = 112;
+
+    /** @staticvar string */
+    const SOAP_FAULT_ATTRIBUTE_ALREADY_IN_SET = '109';
+
+    /** @staticvar string */
+    const SOAP_FAULT_GROUP_ALREADY_IN_SET     = '112';
 
     /**
      * @var AttributeMappingManager


### PR DESCRIPTION
Bug fix: [yes]
Feature addition: [no]
Backwards compatibility break: [no]
Phpspec specification passes: [no]
Checkstyle issues: [no]*
ChangeLog updated: [no]
Fixes the following issue:
