### PR TITLE
MC-175: Url_key are now correctly handled when multiple magento store views are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.1.16 (2015-02-13)
+## Bug fixes
+ - Url_key are now correctly handled when multiple magento store views are used.
+
+# 1.1.15 (2015-02-04)
+## Bug fixes
+ - Manage now properly boolean values.
+
+# 1.1.14 (2015-02-04)
+## Bug fixes
+ - Fix summary info on configurable to get variant group id and label.
+
 # 1.1.13 (2015-01-30)
 ## New features
  - Add an option to prevent or allow removal of products with type non managed by Akeneo.

--- a/Normalizer/ConfigurableNormalizer.php
+++ b/Normalizer/ConfigurableNormalizer.php
@@ -111,6 +111,12 @@ class ConfigurableNormalizer extends AbstractNormalizer
                     true
                 );
 
+                $values[ProductNormalizer::URL_KEY] = sprintf(
+                    '%s-conf-%s',
+                    $values[ProductNormalizer::URL_KEY],
+                    $group->getId()
+                );
+
                 $processedItem[$storeView['code']] = [
                     $sku,
                     $values,

--- a/Webservice/Webservice.php
+++ b/Webservice/Webservice.php
@@ -303,6 +303,10 @@ class Webservice
         }
 
         $this->client->addCall([$resource, $productPart]);
+
+        if (self::SOAP_ACTION_CATALOG_PRODUCT_CREATE === $resource) {
+            $this->updateProductIfMultipleStoreView($productPart);
+        }
     }
 
     /**
@@ -878,5 +882,23 @@ class Webservice
         }
 
         return $productPart;
+    }
+
+    /**
+     * Update product if there is multiple Magento store views.
+     *
+     * @param array $productPart
+     */
+    protected function updateProductIfMultipleStoreView(array $productPart)
+    {
+        $storeViews = $this->getStoreViewsList();
+
+        if (count($storeViews) > 1 && count($productPart) === static::CREATE_PRODUCT_SIZE) {
+            $updateProductPart = array_slice($productPart, static::MAGENTO_STATUS_DISABLE);
+            $this->client->addCall([static::SOAP_ACTION_CATALOG_PRODUCT_UPDATE, $updateProductPart]);
+
+            $updateProductPart[2] = static::ADMIN_STOREVIEW;
+            $this->client->addCall([static::SOAP_ACTION_CATALOG_PRODUCT_UPDATE, $updateProductPart]);
+        }
     }
 }


### PR DESCRIPTION
Bug fix: [yes]
Feature addition: [no]
Backwards compatibility break: [no]
Phpspec specification passes: [no]
Checkstyle issues: [no]*
ChangeLog updated: [yes]
Fixes the following issue: https://akeneo.atlassian.net/browse/MC-175