### PR TITLE
MC-245: Add job_execution.summary.displayed missing translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2.1 (2015-xx-xx)
 ## Improvement
  - Add a tax_class_id attribute to fixtures
+ - Add job_execution.summary.displayed missing translations
 
 # 1.2.0 (2015-03-12)
 ## New feature

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -177,3 +177,4 @@ job_execution.summary:
     product_image_sent:        Products images sent
     product_sent:              Products sent
     product_translation_sent:  Products images sent
+    displayed:                 Warnings

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -177,3 +177,4 @@ job_execution.summary:
     product_image_sent:        Images des produits envoyées
     product_sent:              Produits envoyés
     product_translation_sent:  Traduction des produits envoyées
+    displayed:                 Alertes


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Yes
| New feature?         | No
| BC breaks?           | No
| Tests pass?          | N/A
| Checkstyle issues?*  | N/A
| PMD issues?**        | N/A
| Changelog updated?   | Yes
| Fixed tickets        | MC-245
| DB schema updated?   | No
| Migration script?    | No
| Doc PR               | No