### PR TITLE
MC-251: Emptied fields in Akeneo are cleared in Magento by the product export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#1.2.3 (2015-07-07)
+## Bug fix
+ - Check if associated product is complete and enable before association export
+ - Correct product association when SKU is full number
+ - Emptied fields in Akeneo are cleared in Magento by the product export
+
 #1.2.2 (2015-03-30)
 ## Bug fix
  - Fix regression on Magento extension to get PIM version

--- a/Normalizer/ProductValueNormalizer.php
+++ b/Normalizer/ProductValueNormalizer.php
@@ -28,6 +28,9 @@ class ProductValueNormalizer implements NormalizerInterface
     /** @staticvar string */
     const GLOBAL_SCOPE = 'global';
 
+    /** @staticvar string */
+    const BOOLEAN_TYPE = 'pim_catalog_boolean';
+
     /**
      * {@inheritdoc}
      */
@@ -84,9 +87,8 @@ class ProductValueNormalizer implements NormalizerInterface
         $localeCode,
         $onlyLocalized
     ) {
-        return (
+        $isValueNormalizable = (
             ($value !== $identifier) &&
-            ($value->getData() !== null) &&
             $this->isScopeNormalizable($value, $scopeCode) &&
             $this->isLocaleNormalizable($value, $localeCode) &&
             (
@@ -97,6 +99,8 @@ class ProductValueNormalizer implements NormalizerInterface
             $this->attributeIsNotIgnored($attributeCode) &&
             !($value->getData() instanceof AbstractProductMedia)
         );
+
+        return $isValueNormalizable;
     }
 
     /**
@@ -180,8 +184,16 @@ class ProductValueNormalizer implements NormalizerInterface
         MappingCollection $attributeMapping,
         $currencyCode
     ) {
-        $data          = $value->getData();
-        $attribute     = $value->getAttribute();
+        $attribute = $value->getAttribute();
+        $data      = $value->getData();
+
+        if (null === $data) {
+            if (static::BOOLEAN_TYPE === $attribute->getAttributeType()) {
+                $data = false;
+            } else {
+                $data = '';
+            }
+        }
 
         if (!isset($magentoAttributes[$attributeCode])) {
             throw new AttributeNotFoundException(

--- a/spec/Pim/Bundle/MagentoConnectorBundle/Normalizer/ProductValueNormalizerSpec.php
+++ b/spec/Pim/Bundle/MagentoConnectorBundle/Normalizer/ProductValueNormalizerSpec.php
@@ -40,7 +40,6 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     function it_normalizes_a_scopable_value($value, $attribute)
     {
         $attribute->isScopable()->willReturn(true);
-
         $attribute->isLocalizable()->willReturn(false);
 
         $this->normalize($value, 'MagentoArray', $this->globalContext)->shouldReturn(['attribute_code' => 'hello']);

--- a/spec/Pim/Bundle/MagentoConnectorBundle/Processor/ProductAssociationProcessorSpec.php
+++ b/spec/Pim/Bundle/MagentoConnectorBundle/Processor/ProductAssociationProcessorSpec.php
@@ -73,7 +73,7 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
 
         $associatedProduct->getIdentifier()->willReturn('sku-011');
         $associatedProduct->isEnabled()->willReturn(true);
-        $associatedProduct->getCompletenesses()->willReturn($completeness);
+        $associatedProduct->getCompletenesses()->willReturn([$completeness]);
         $completeness->getRatio()->willReturn(100);
 
         $associationType->getCode()->willReturn('UPSELL');


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bug fix?             | Yes
| New feature?         | No
| BC breaks?           | No
| Tests pass?          | Yes
| Checkstyle issues?*  | No
| PMD issues?**        | No
| Changelog updated?   | Yes
| Fixed tickets        | MC-251
| DB schema updated?   | No
| Migration script?    | No
| Doc PR               | No
